### PR TITLE
Increase Speed (#29)

### DIFF
--- a/dask_sql/datacontainer.py
+++ b/dask_sql/datacontainer.py
@@ -1,0 +1,161 @@
+from typing import List, Dict, Tuple, Union
+
+import dask.dataframe as dd
+
+
+ColumnType = Union[str, int]
+
+
+class ColumnContainer:
+    # Forward declaration
+    pass
+
+
+class ColumnContainer:
+    """
+    Helper class to store a list of columns,
+    which do not necessarily be the ones of the dask dataframe.
+    Instead, the container also stores a mapping from "frontend"
+    columns (columns with the names and order expected by SQL)
+    to "backend" columns (the real column names used by dask)
+    to prevent unnecessary renames.
+    """
+
+    def __init__(
+        self,
+        frontend_columns: List[str],
+        frontend_backend_mapping: Union[Dict[str, ColumnType], None] = None,
+    ):
+        assert all(
+            isinstance(col, str) for col in frontend_columns
+        ), "All frontend columns need to be of string type"
+        self._frontend_columns = list(frontend_columns)
+        if frontend_backend_mapping is None:
+            self._frontend_backend_mapping = {
+                col: col for col in self._frontend_columns
+            }
+        else:
+            self._frontend_backend_mapping = frontend_backend_mapping
+
+    def _copy(self) -> ColumnContainer:
+        """
+        Internal function to copy this container
+        """
+        return ColumnContainer(self._frontend_columns, self._frontend_backend_mapping)
+
+    def limit_to(self, fields: List[str]) -> ColumnContainer:
+        """
+        Create a new ColumnContainer, which has frontend columns
+        limited to only the ones given as parameter.
+        Also uses the order of these as the new column order.
+        """
+        assert all(f in self._frontend_backend_mapping for f in fields)
+        cc = self._copy()
+        cc._frontend_columns = [str(x) for x in fields]
+        return cc
+
+    def rename(self, columns: Dict[str, str]) -> ColumnContainer:
+        """
+        Return a new ColumnContainer where the frontend columns
+        are renamed according to the given mapping.
+        Columns not present in the mapping are not touched,
+        the order is preserved.
+        """
+        cc = self._copy()
+        for column_from, column_to in columns.items():
+            backend_column = self._frontend_backend_mapping[str(column_from)]
+            cc._frontend_backend_mapping[str(column_to)] = backend_column
+
+        cc._frontend_columns = [
+            str(columns[col]) if col in columns else col
+            for col in self._frontend_columns
+        ]
+
+        return cc
+
+    def mapping(self) -> List[Tuple[str, ColumnType]]:
+        """
+        The mapping from frontend columns to backend columns.
+        """
+        return list(self._frontend_backend_mapping.items())
+
+    @property
+    def columns(self) -> List[str]:
+        """
+        The stored frontend columns in the correct order
+        """
+        return self._frontend_columns
+
+    def add(
+        self, frontend_column: str, backend_column: Union[str, None] = None
+    ) -> ColumnContainer:
+        """
+        Return a new ColumnContainer with the
+        given column added.
+        The column is added at the last position in the column list.
+        """
+        cc = self._copy()
+
+        frontend_column = str(frontend_column)
+
+        cc._frontend_backend_mapping[frontend_column] = str(
+            backend_column or frontend_column
+        )
+        cc._frontend_columns.append(frontend_column)
+
+        return cc
+
+    def get_backend_by_frontend_index(self, index: int) -> str:
+        """
+        Get back the dask column, which is referenced by the
+        frontend (SQL) column with the given index.
+        """
+        frontend_column = self._frontend_columns[index]
+        backend_column = self._frontend_backend_mapping[frontend_column]
+        return backend_column
+
+    def make_unique(self, prefix="col"):
+        """
+        Make sure we have unique column names by calling each column
+
+            <prefix>_<number>
+
+        where <number> is the column index.
+        """
+        return self.rename(
+            columns={str(col): f"{prefix}_{i}" for i, col in enumerate(self.columns)}
+        )
+
+
+class DataContainer:
+    """
+    In SQL, every column operation or reference is done via
+    the column index. Some dask operations, such as grouping,
+    joining or concatenating preserve the columns in a different
+    order than SQL would expect.
+    However, we do not want to change the column data itself
+    all the time (because this would lead to computational overhead),
+    but still would like to keep the columns accessible by name and index.
+    For this, we add an additional `ColumnContainer` to each dataframe,
+    which does all the column mapping between "frontend"
+    (what SQL expects, also in the correct order)
+    and "backend" (what dask has).
+    """
+
+    def __init__(self, df: dd.DataFrame, column_container: ColumnContainer):
+        self.df = df
+        self.column_container = column_container
+
+    def assign(self) -> dd.DataFrame:
+        """
+        Combine the column mapping with the actual data and return
+        a dataframe which has the the columns specified in the
+        stored ColumnContainer.
+        """
+        df = self.df.assign(
+            **{
+                col_from: self.df[col_to]
+                for col_from, col_to in self.column_container.mapping()
+            }
+        )
+        return df[self.column_container.columns]

--- a/dask_sql/physical/rel/logical/filter.py
+++ b/dask_sql/physical/rel/logical/filter.py
@@ -4,6 +4,7 @@ import dask.dataframe as dd
 
 from dask_sql.physical.rex import RexConverter
 from dask_sql.physical.rel.base import BaseRelPlugin
+from dask_sql.datacontainer import DataContainer
 
 
 class LogicalFilterPlugin(BaseRelPlugin):
@@ -16,13 +17,16 @@ class LogicalFilterPlugin(BaseRelPlugin):
 
     def convert(
         self, rel: "org.apache.calcite.rel.RelNode", context: "dask_sql.Context"
-    ) -> dd.DataFrame:
-        (df,) = self.assert_inputs(rel, 1, context)
-        self.check_columns_from_row_type(df, rel.getExpectedInputRowType(0))
+    ) -> DataContainer:
+        (dc,) = self.assert_inputs(rel, 1, context)
+        df = dc.df
+        cc = dc.column_container
 
+        # Every logic is handled in the RexConverter
+        # we just need to apply it here
         condition = rel.getCondition()
-        df_condition = RexConverter.convert(condition, df, context=context)
+        df_condition = RexConverter.convert(condition, dc, context=context)
         df = df[df_condition]
 
-        df = self.fix_column_to_row_type(df, rel.getRowType())
-        return df
+        cc = self.fix_column_to_row_type(cc, rel.getRowType())
+        return DataContainer(df, cc)

--- a/dask_sql/physical/rel/logical/union.py
+++ b/dask_sql/physical/rel/logical/union.py
@@ -4,6 +4,7 @@ import dask.dataframe as dd
 
 from dask_sql.physical.rex import RexConverter
 from dask_sql.physical.rel.base import BaseRelPlugin
+from dask_sql.datacontainer import DataContainer, ColumnContainer
 
 
 class LogicalUnionPlugin(BaseRelPlugin):
@@ -16,25 +17,41 @@ class LogicalUnionPlugin(BaseRelPlugin):
 
     def convert(
         self, rel: "org.apache.calcite.rel.RelNode", context: "dask_sql.Context"
-    ) -> dd.DataFrame:
-        first_df, second_df = self.assert_inputs(rel, 2, context)
+    ) -> DataContainer:
+        first_dc, second_dc = self.assert_inputs(rel, 2, context)
+
+        first_df = first_dc.df
+        first_cc = first_dc.column_container
+
+        second_df = second_dc.df
+        second_cc = second_dc.column_container
 
         # For concatenating, they should have exactly the same fields
         output_field_names = [str(x) for x in rel.getRowType().getFieldNames()]
-        assert len(first_df.columns) == len(output_field_names)
-        first_df = first_df.rename(
+        assert len(first_cc.columns) == len(output_field_names)
+        first_cc = first_cc.rename(
             columns={
                 col: output_col
-                for col, output_col in zip(first_df.columns, output_field_names)
+                for col, output_col in zip(first_cc.columns, output_field_names)
             }
         )
-        assert len(second_df.columns) == len(output_field_names)
-        second_df = second_df.rename(
+        first_dc = DataContainer(first_df, first_cc)
+
+        assert len(second_cc.columns) == len(output_field_names)
+        second_cc = second_cc.rename(
             columns={
                 col: output_col
-                for col, output_col in zip(second_df.columns, output_field_names)
+                for col, output_col in zip(second_cc.columns, output_field_names)
             }
         )
+        second_dc = DataContainer(second_df, second_cc)
+
+        # To concat the to dataframes, we need to make sure the
+        # columns actually have the specified names in the
+        # column containers
+        # Otherwise the concat won't work
+        first_df = first_dc.assign()
+        second_df = second_dc.assign()
 
         self.check_columns_from_row_type(first_df, rel.getExpectedInputRowType(0))
         self.check_columns_from_row_type(second_df, rel.getExpectedInputRowType(1))
@@ -44,5 +61,6 @@ class LogicalUnionPlugin(BaseRelPlugin):
         if not rel.all:
             df = df.drop_duplicates()
 
-        df = self.fix_column_to_row_type(df, rel.getRowType())
-        return df
+        cc = ColumnContainer(df.columns)
+        cc = self.fix_column_to_row_type(cc, rel.getRowType())
+        return DataContainer(df, cc)

--- a/dask_sql/physical/rex/base.py
+++ b/dask_sql/physical/rex/base.py
@@ -2,6 +2,8 @@ from typing import Union, Any
 
 import dask.dataframe as dd
 
+from dask_sql.datacontainer import DataContainer
+
 
 class BaseRexPlugin:
     """
@@ -17,7 +19,7 @@ class BaseRexPlugin:
     def convert(
         self,
         rex: "org.apache.calcite.rex.RexNode",
-        df: dd.DataFrame,
+        dc: DataContainer,
         context: "dask_sql.Context",
     ) -> Union[dd.Series, Any]:
         """Base method to implement"""

--- a/dask_sql/physical/rex/convert.py
+++ b/dask_sql/physical/rex/convert.py
@@ -5,6 +5,7 @@ import dask.dataframe as dd
 from dask_sql.java import get_java_class
 from dask_sql.utils import Pluggable
 from dask_sql.physical.rex.base import BaseRexPlugin
+from dask_sql.datacontainer import DataContainer
 
 
 class RexConverter(Pluggable):
@@ -32,7 +33,7 @@ class RexConverter(Pluggable):
     def convert(
         cls,
         rex: "org.apache.calcite.rex.RexNode",
-        df: dd.DataFrame,
+        dc: DataContainer,
         context: "dask_sql.Context",
     ) -> Union[dd.DataFrame, Any]:
         """
@@ -50,5 +51,5 @@ class RexConverter(Pluggable):
                 f"No conversion for class {class_name} available (yet)."
             )
 
-        df = plugin_instance.convert(rex, df=df, context=context)
+        df = plugin_instance.convert(rex, dc, context=context)
         return df

--- a/dask_sql/physical/rex/core/call.py
+++ b/dask_sql/physical/rex/core/call.py
@@ -10,6 +10,7 @@ import dask.dataframe as dd
 from dask_sql.physical.rex import RexConverter
 from dask_sql.physical.rex.base import BaseRexPlugin
 from dask_sql.utils import is_frame
+from dask_sql.datacontainer import DataContainer
 
 
 class Operation:
@@ -202,12 +203,12 @@ class RexCallPlugin(BaseRexPlugin):
     def convert(
         self,
         rex: "org.apache.calcite.rex.RexNode",
-        df: dd.DataFrame,
+        dc: DataContainer,
         context: "dask_sql.Context",
     ) -> Union[dd.Series, Any]:
         # Prepare the operands by turning the RexNodes into python expressions
         operands = [
-            RexConverter.convert(o, df, context=context) for o in rex.getOperands()
+            RexConverter.convert(o, dc, context=context) for o in rex.getOperands()
         ]
 
         # Now use the operator name in the mapping

--- a/dask_sql/physical/rex/core/input_ref.py
+++ b/dask_sql/physical/rex/core/input_ref.py
@@ -1,6 +1,7 @@
 import dask.dataframe as dd
 
 from dask_sql.physical.rex.base import BaseRexPlugin
+from dask_sql.datacontainer import DataContainer
 
 
 class RexInputRefPlugin(BaseRexPlugin):
@@ -15,9 +16,13 @@ class RexInputRefPlugin(BaseRexPlugin):
     def convert(
         self,
         rex: "org.apache.calcite.rex.RexNode",
-        df: dd.DataFrame,
+        dc: DataContainer,
         context: "dask_sql.Context",
     ) -> dd.Series:
+        df = dc.df
+        cc = dc.column_container
+
         # The column is references by index
         index = rex.getIndex()
-        return df.iloc[:, index]
+        backend_column_name = cc.get_backend_by_frontend_index(index)
+        return df[backend_column_name]

--- a/dask_sql/physical/rex/core/literal.py
+++ b/dask_sql/physical/rex/core/literal.py
@@ -1,9 +1,11 @@
 from typing import Any
 
+import numpy as np
 import dask.dataframe as dd
 
 from dask_sql.physical.rex.base import BaseRexPlugin
 from dask_sql.mappings import sql_to_python_value
+from dask_sql.datacontainer import DataContainer
 
 
 class RexLiteralPlugin(BaseRexPlugin):
@@ -21,7 +23,7 @@ class RexLiteralPlugin(BaseRexPlugin):
     def convert(
         self,
         rex: "org.apache.calcite.rex.RexNode",
-        df: dd.DataFrame,
+        dc: DataContainer,
         context: "dask_sql.Context",
     ) -> Any:
         literal_value = rex.getValue()

--- a/tests/integration/test_select.py
+++ b/tests/integration/test_select.py
@@ -14,6 +14,15 @@ class SelectTestCase(DaskTestCase):
 
         assert_frame_equal(df, self.df)
 
+    def test_select_alias(self):
+        df = self.c.sql("SELECT a as b, b as a FROM df")
+        df = df.compute()
+
+        expected_df = self.df
+        expected_df.assign(a=self.df.b, b=self.df.a)
+
+        assert_frame_equal(df, expected_df)
+
     def test_select_column(self):
         df = self.c.sql("SELECT a FROM df")
         df = df.compute()


### PR DESCRIPTION
* Start adding a datacontainer

This container splits up the real dataframe from the column names so that we do not need to have that many column renames anymore

* Use the new datatype in the rex classes

* Use the new datatype in the context

* Use the new datatype in the physical plans

* Remove the now outdated make_unique function

* Make sure to always have a str column

* Add a shortcut to not create the same column again and again

* Add a test for aliases

* Re-add the column fixing

* Some more comments